### PR TITLE
removed beta tag due to version change

### DIFF
--- a/hello.yaml
+++ b/hello.yaml
@@ -1,4 +1,5 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
+#apiVersion: apps/v1beta1 # done for K8S version > 1.16
 kind: Deployment
 metadata:
   name: hello-k8s-deployment


### PR DESCRIPTION
in https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ the Kubernetes "beta" API has been deprecated. Changing the deployment script to make it work in newer versions.